### PR TITLE
Different left icon depending on prefix 

### DIFF
--- a/scripts/dracula.sh
+++ b/scripts/dracula.sh
@@ -48,6 +48,7 @@ main()
   left_icon=$(get_tmux_option "@dracula-show-left-icon" smiley)
   left_icon_bg=$(get_tmux_option "@dracula-left-icon-bg" green)
   left_icon_fg=$(get_tmux_option "@dracula-left-icon-fg" dark_gray)
+  left_icon_prefix=$(get_tmux_option "@dracula-show-left-icon-prefix" session)
   left_icon_prefix_bg=$(get_tmux_option "@dracula-left-icon-prefix-on-bg" red)
   left_icon_prefix_fg=$(get_tmux_option "@dracula-left-icon-prefix-on-fg" white)
   left_icon_padding_left=$(get_tmux_option "@dracula-left-icon-padding-left" 1)
@@ -146,6 +147,17 @@ main()
       left_icon_content=$left_icon;;
   esac
 
+  case $left_icon_prefix in
+    smiley)
+      left_icon_content_prefix="☺";;
+    session)
+      left_icon_content_prefix="#S";;
+    window)
+      left_icon_content_prefix="#W";;
+    *)
+      left_icon_content_prefix=$left_icon_prefix;;
+  esac
+
   # Handle left icon padding
   icon_pd_l=""
   if [ "$left_icon_padding_left" -gt "0" ]; then
@@ -166,7 +178,7 @@ main()
   tmux set-option -g status-left "\
 #{?client_prefix,#[fg=${!left_icon_prefix_fg}],#[fg=${!left_icon_fg}]}\
 #{?client_prefix,#[bg=${!left_icon_prefix_bg}],#[bg=${!left_icon_bg}]}\
-${icon_pd_l}${left_icon_content}${icon_pd_r}\
+${icon_pd_l}#{?client_prefix,${left_icon_content_prefix},${left_icon_content}}${icon_pd_r}\
 #{?client_prefix,#[fg=${!left_icon_prefix_bg}],#[fg=${!left_icon_bg}]}\
 #[bg=${!status_bg}]\
 ${left_sep}\


### PR DESCRIPTION
Adds the `@dracula-show-left-icon-prefix` option that'll take the place of `@dracula-show-left-icon` when the prefix is active

![Screen Recording 2023-07-11 at 8 41 38 pm](https://github.com/Erimus-Koo/dracula-tmux/assets/42397332/903fe71f-3ccd-4182-a39d-8b4b27d76930)

<details>
<summary>My .tmux.conf</summary>

```
# dracula theme {

  # general {
    set -g @dracula-show-powerline true  # Enable powerline symbols
    # separator for left
    set -g @dracula-show-left-sep   # █     
    # separator for right symbol (can set any symbol you like as seperator)
    set -g @dracula-show-right-sep   # █     

    set -g @dracula-border-contrast true  # pane edge highlight
    set -g @dracula-status-bg 'gray'
  # }

  # left icon area {
    set -g @dracula-show-left-icon ' Rackodo' # before window #S     🔍  
    set -g @dracula-show-left-icon-prefix ' WAITING'
    # set -g @dracula-show-left-icon '卵#S #{?window_zoomed_flag, ,}' # before window #S     🔍  
    set -g @dracula-left-icon-padding-left 1
    set -g @dracula-left-icon-padding-right 1
    set -g @dracula-left-icon-margin-right 0
    set -g @dracula-left-icon-bg 'cyan'
    set -g @dracula-left-icon-fg 'dark_gray'
    set -g @dracula-left-icon-prefix-on-bg 'white'
    set -g @dracula-left-icon-prefix-on-fg 'dark_gray'
  # }

  # window area{
    set -g @dracula-show-flags false  # marks of recent windows
    # inactivty window
    set -g @dracula-window-bg 'gray'
    set -g @dracula-window-fg 'light_purple'
    # activty window
    set -g @dracula-window-current-bg 'green'
    set -g @dracula-window-current-fg 'dark_gray'
    # padding
    set -g @dracula-window-padding-left 0 
    set -g @dracula-window-padding-right 0
    set -g @dracula-window-margin-right 0
    # separator mark, set to "" same as the show-sep
    set -g @dracula-window-left-sep ''  #    
    set -g @dracula-window-right-sep ''  #    
    set -g @dracula-window-left-sep-invert false
    # use customized window tag
    set -g @dracula-window-disabled true

    # Dracula Color Pallette{
      white='#f8f8f2'
      gray='#44475a'
      dark_gray='#282a36'
      light_purple='#bd93f9'
      dark_purple='#6272a4'
      cyan='#8be9fd'
      green='#50fa7b'
      orange='#ffb86c'
      red='#ff5555'
      pink='#ff79c6'
      yellow='#f1fa8c'
    # }

    set-window-option -g window-status-format "\
  #[fg=${cyan}]#I:#W#[fg=${dark_purple}] \\ \
#[fg=${orange}]\
#{?window_zoomed_flag, ,}\
#(pwd=\"#{pane_current_path}\"; echo \${pwd####*/})\
  "
    set-window-option -g window-status-current-format "\
#[bg=${gray},fg=${cyan}]#[bg=${cyan},fg=${dark_gray}] #I:#W\
 #[fg=${cyan},bg=${orange}]\
 #[fg=${yellow}]#{?window_zoomed_flag, ,}\
#[fg=${dark_gray}]\
#(pwd=\"#{pane_current_path}\"; echo \${pwd####*/})\
 #[fg=${orange},bg=${gray}]"
  # }

  # plugins{
    set -g @dracula-show-empty-plugins false    # hide empty plugin
    # plugins padding
    set -g @dracula-plugin-padding-left 1
    set -g @dracula-plugin-padding-right 1
    set -g @dracula-plugin-padding-rightmost 1

    # available plugins: battery, cpu-usage, git, gpu-usage, ram-usage, network, network-bandwidth, network-ping, attached-clients, network-vpn, weather, time, spotify-tui, kubernetes-context
    set -g @dracula-plugins "git weather battery time"


    # available colors: white, gray, dark_gray, light_purple, dark_purple, cyan, green, orange, red, pink, yellow
    # set -g @dracula-[plugin-name]-colors "[background] [foreground]"

    # git
    set -g @dracula-git-colors "orange dark_gray"

    # network
    set -g @dracula-ping-server "baidu.com"
    set -g @dracula-ping-rate 1
    set -g @dracula-ping-label ""
    set -g @dracula-network-ping-colors "dark_gray light_purple"
    # set -g @dracula-network-bandwidth eth0
    # set -g @dracula-network-bandwidth-interval 0
    # set -g @dracula-network-bandwidth-show-interface false

    # ram & cpu
    set -g @dracula-ram-usage-label ""
    set -g @dracula-ram-usage-colors "cyan gray"
    set -g @dracula-cpu-usage-label ""  # 
    set -g @dracula-cpu-display-load false  # T:avg load, F:percent
    set -g @dracula-cpu-usage-colors "red white"

    # weather
    set -g @dracula-show-fahrenheit false   # use celsius
    # set -g @dracula-fixed-location "Beijing"
    set -g @dracula-show-location false
    set -g @dracula-weather-colors "gray cyan"

    # battery
    set -g @dracula-battery-label ""  #  
    set -g @dracula-battery-colors "dark_gray pink"

    # time
    set -g @dracula-time-colors "light_purple dark_gray"
    set -g @dracula-military-time true      # 24 hours format
    set -g @dracula-show-timezone false     # hide timezone
  # }
# }
```